### PR TITLE
Fix magic wall and wild growth rune bug (#601)

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -2849,6 +2849,7 @@
 	</item>
 	<item id="2128" article="a" name="magic wall">
 		<attribute key="type" value="magicfield"/>
+		<attribute key="blocking" value="1"/>
 		<attribute key="duration" value="20"/>
 		<attribute key="decayTo" value="0"/>
 	</item>
@@ -2858,7 +2859,7 @@
 	<item id="2130" article="a" name="rush wood">
 		<attribute key="type" value="magicfield"/>
 		<attribute key="blocking" value="1"/>
-		<attribute key="duration" value="45"/>
+		<attribute key="duration" value="20"/>
 		<attribute key="decayTo" value="0"/>
 	</item>
 	<item id="2131" article="a" name="fire field">

--- a/data/scripts/spells/runes/magic_wall.lua
+++ b/data/scripts/spells/runes/magic_wall.lua
@@ -1,18 +1,22 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGY)
-
 function onCreateMagicWall(creature, tile)
-	local item = Game.createItem(Game.getWorldType() == WORLD_TYPE_NO_PVP and ITEM_MAGICWALL_SAFE or ITEM_MAGICWALL, 1, tile)
-	item:setAttribute(ITEM_ATTRIBUTE_DURATION, math.random(14000, 20000))
+	local magicWall
+	if Game.getWorldType() == WORLD_TYPE_NO_PVP then
+		magicWall = ITEM_MAGICWALL_SAFE
+	else
+		magicWall = ITEM_MAGICWALL
+	end
+	local item = Game.createItem(magicWall, 1, tile)
+	item:setDuration(16, 24)
 end
 
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGY)
 combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onCreateMagicWall")
 
 local spell = Spell("rune")
 function spell.onCastSpell(creature, variant, isHotkey)
-    return combat:execute(creature, variant)
+	return combat:execute(creature, variant)
 end
-
 
 spell:name("Magic Wall Rune")
 spell:group("attack")

--- a/data/scripts/spells/runes/wild_growth.lua
+++ b/data/scripts/spells/runes/wild_growth.lua
@@ -1,16 +1,21 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_EARTH)
-
-function onCreateMagicWall(creature, tile)
-	local item = Game.createItem(Game.getWorldType() == WORLD_TYPE_NO_PVP and ITEM_WILDGROWTH_SAFE or ITEM_WILDGROWTH, 1, tile)
-	item:setAttribute(ITEM_ATTRIBUTE_DURATION, math.random(38000, 45000))
+function onCreateWildGrowth(creature, tile)
+	local wildGrowth
+	if Game.getWorldType() == WORLD_TYPE_NO_PVP then
+		wildGrowth = ITEM_WILDGROWTH_SAFE
+	else
+		wildGrowth = ITEM_WILDGROWTH
+	end
+	local item = Game.createItem(wildGrowth, 1, tile)
+	item:setDuration(30, 60)
 end
 
-combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onCreateMagicWall")
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGY)
+combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onCreateWildGrowth")
 
 local spell = Spell("rune")
 function spell.onCastSpell(creature, variant, isHotkey)
-    return combat:execute(creature, variant)
+	return combat:execute(creature, variant)
 end
 
 spell:name("Wild Growth Rune")


### PR DESCRIPTION
https://github.com/opentibiabr/canary/commit/f5fb2551c0bcb49deb311e94bc2469017648861f

Created a new function to set the min/max duration of an item, id to decay and whether or not to show the duration

Fixed mw being walkable, fixing a small typo in blocking parse

Usage of setDuration:
item:setDuration(minduration, maxduration = 0, decayid = 0, showDuration = true)


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
